### PR TITLE
chore(codeowners): rename @Staffbase/south-park → @Staffbase/product-app-and-release-mng

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Staffbase/south-park
+*       @Staffbase/product-app-and-release-mng


### PR DESCRIPTION
The team `@Staffbase/south-park` was renamed to `@Staffbase/product-app-and-release-mng` as part of the org structure update (`south-park` → "Product · App and Release Mng", unit: Foundations).

The old team slug currently 404s, so CODEOWNERS lines referencing it cannot be auto-requested for review. This PR updates the references in this repo's `.github/CODEOWNERS`.

Changes:
- `@Staffbase/south-park` → `@Staffbase/product-app-and-release-mng`
- `# Southpark` → `# Product App and Release Mng` (comment header, where present)

No filesystem paths or other team references were touched.