### PR TITLE
APP-0000: replaced southpark occurences

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Staffbase/south-park
+*       @Staffbase/app-and-release-mng


### PR DESCRIPTION
This PR does not change any logic. It is purely a string replacement: occurrences of the former team name "south park" / "SouthPark" / "south-park" have been replaced with "App and Release Mng" / "app-and-release-mng" to reflect the current team name.